### PR TITLE
Adds gitignore for text editor specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ target
 .idea
 *.iml
 .DS_Store
+
+    
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json


### PR DESCRIPTION
If you use another text editor you can mention it here, or just accept the pull request to omit vs code specific files.