### PR TITLE
Fixing jsoup clean to preserve line break

### DIFF
--- a/src/main/java/com/google/codeu/servlets/AboutMeServlet.java
+++ b/src/main/java/com/google/codeu/servlets/AboutMeServlet.java
@@ -14,6 +14,7 @@ import com.google.codeu.data.User;
 
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import org.jsoup.nodes.Document.OutputSettings;
 
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
@@ -64,7 +65,7 @@ public class AboutMeServlet extends HttpServlet{
     }
 
     String userEmail = userService.getCurrentUser().getEmail();
-    String aboutMe = Jsoup.clean(request.getParameter("about-me"), Whitelist.none());
+    String aboutMe = Jsoup.clean(request.getParameter("about-me"), "", Whitelist.none(), new OutputSettings().prettyPrint(false));
 
     // Process markdown
     Parser parser = Parser.builder().build();

--- a/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
@@ -15,6 +15,7 @@ import com.google.codeu.data.Message;
 import com.google.gson.Gson;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import org.jsoup.nodes.Document.OutputSettings;
 
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
@@ -60,7 +61,7 @@ public class MessageFeedServlet extends HttpServlet{
    }
 
    String userEmail = userService.getCurrentUser().getEmail();
-   String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+   String text = Jsoup.clean(request.getParameter("text"), "", Whitelist.none(), new OutputSettings().prettyPrint(false));
 
    // Process markdown
    Parser parser = Parser.builder().build();

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -29,6 +29,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import org.jsoup.nodes.Document.OutputSettings;
+
 
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
@@ -80,8 +82,8 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
-    
+    String text = Jsoup.clean(request.getParameter("text"), "", Whitelist.none(), new OutputSettings().prettyPrint(false));
+
     // Process markdown
     Parser parser = Parser.builder().build();
     Node document = parser.parse(text);

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -38,6 +38,8 @@
    isn't too close to the border. */
 .message-body {
   margin: 5px;
+  word-wrap: break-word;
+  white-space: pre;
 }
 
 /* Use this to hide certain elements like forms if the


### PR DESCRIPTION
- There are two methods for Jsoup.clean, I change to the other one:
clean​(String bodyHtml, String baseUri, Whitelist whitelist, Document.OutputSettings outputSettings)
- prettyPrint in OutputSettings substitutes the line break with a single space so I set it to false.
- add css to .message-body to break the line when it is too long and preserve all the whitespace as typed in.